### PR TITLE
Update Gemfile.lock to make Dependabot (and maybe other tools) happy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,11 +5,6 @@ GIT
     turbolinks (3.0.0)
       coffee-rails
 
-PATH
-  remote: ../percy-capybara
-  specs:
-    percy-capybara (4.0.0.pre.beta1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -96,8 +91,9 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
+    percy-capybara (4.0.0.pre.beta2)
     public_suffix (3.0.3)
-    puma (3.6.2)
+    puma (3.12.0)
     rack (2.0.6)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -177,8 +173,8 @@ DEPENDENCIES
   coffee-rails
   database_cleaner
   jquery-rails
-  percy-capybara!
-  puma
+  percy-capybara (~> 4.0.0.pre.beta2)
+  puma (~> 3.10)
   rails (~> 5.0.0)
   rails_12factor
   sass-rails


### PR DESCRIPTION
Looks like I did not update the `Gemfile.lock` when I updated the `Gemfile` to the new pre-release of `percy-capybara`, and while CI passes, this is making Dependabot a sad camper (see: https://github.com/percy/example-rails/issues/9).

