### PR TITLE
fix migration version

### DIFF
--- a/db/migrate/20150507181847_create_todos.rb
+++ b/db/migrate/20150507181847_create_todos.rb
@@ -1,4 +1,4 @@
-class CreateTodos < ActiveRecord::Migration
+class CreateTodos < ActiveRecord::Migration[5.0]
   def change
     create_table :todos do |t|
       t.string :title

--- a/db/migrate/20150519181601_add_session_user_to_todos.rb
+++ b/db/migrate/20150519181601_add_session_user_to_todos.rb
@@ -1,4 +1,4 @@
-class AddSessionUserToTodos < ActiveRecord::Migration
+class AddSessionUserToTodos < ActiveRecord::Migration[5.0]
   def change
     add_column :todos, :session_user_id, :string
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150519181601) do
+ActiveRecord::Schema.define(version: 2015_05_19_181601) do
 
   create_table "todos", force: :cascade do |t|
-    t.string   "title"
-    t.boolean  "is_completed",    default: false
-    t.datetime "created_at",                      null: false
-    t.datetime "updated_at",                      null: false
-    t.string   "session_user_id"
+    t.string "title"
+    t.boolean "is_completed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "session_user_id"
   end
 
 end


### PR DESCRIPTION
I had migration file errors like bellow when I tried to exec `bundle exec rails db:create db:migrate` .
This error is not good for beginners.
These migration files were made by rails `5.0` [right](https://github.com/percy/example-rails/commit/6ea021f47299d18de8794f09e637fd437c2ca0ac#diff-8b7db4d5cc4b8f6dc8feb7030baa2478) ?
I specified rails version and added new auto generated schema.rb


```
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateTodos < ActiveRecord::Migration[4.2]
```